### PR TITLE
Support For-Each-Join Loops

### DIFF
--- a/language_tour.md
+++ b/language_tour.md
@@ -382,7 +382,7 @@ for joined in join(rows1, rows2) {
 ```
 
 Garble automatically joins the arrays in a for-each-join loop using a [bitonic sorting network](https://en.wikipedia.org/wiki/Bitonic_sorter), more concretely implementing the paper [Private Set Intersection:
-Are Garbled Circuits Better than Custom Protocols?](https://www.ndss-symposium.org/wp-content/uploads/2017/09/06_4.pdf), which has a circuit complexity of `(m + n) * log(m + n)` instead of `m * n` which would result from joining the arrays using nested loops. **The arrays that are joined in the loop must be sorted**, otherwise elements might be discarded or invalid data returned.
+Are Garbled Circuits Better than Custom Protocols?](https://www.ndss-symposium.org/wp-content/uploads/2017/09/06_4.pdf) without the shuffle step, which has a circuit complexity of `(m + n) * log(m + n)` instead of `m * n` which would result from joining the arrays using nested loops. **The arrays that are joined in the loop must be sorted**, otherwise elements might be discarded or invalid data returned.
 
 For-each-join loops always join two arrays based on the first field. If you would like to compare more than one field for equality, the easiest way is to transform the sorted array so that the relevant fields are grouped together in a tuple and thus form the first field. Such a transformation will be completely optimized away by the Garble compiler, such as in the following example, which groups together the first two fields, compiled to a circuit with 0 gates:
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -279,7 +279,7 @@ pub enum StmtEnum<T> {
     /// Binds an identifier to each value of an array expr, evaluating the body.
     ForEachLoop(String, Expr<T>, Vec<Stmt<T>>),
     /// Binds an identifier to each joined row of two tables, evaluating the body.
-    JoinLoop(String, usize, (Expr<T>, Expr<T>), Vec<Stmt<T>>),
+    JoinLoop(String, (Expr<T>, Expr<T>), Vec<Stmt<T>>),
     /// An expression (all expressions are statements, but not all statements expressions).
     Expr(Expr<T>),
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -279,7 +279,7 @@ pub enum StmtEnum<T> {
     /// Binds an identifier to each value of an array expr, evaluating the body.
     ForEachLoop(String, Expr<T>, Vec<Stmt<T>>),
     /// Binds an identifier to each joined row of two tables, evaluating the body.
-    JoinLoop(String, (Expr<T>, Expr<T>), Vec<Stmt<T>>),
+    JoinLoop(String, T, (Expr<T>, Expr<T>), Vec<Stmt<T>>),
     /// An expression (all expressions are statements, but not all statements expressions).
     Expr(Expr<T>),
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -278,6 +278,8 @@ pub enum StmtEnum<T> {
     ArrayAssign(String, Expr<T>, Expr<T>),
     /// Binds an identifier to each value of an array expr, evaluating the body.
     ForEachLoop(String, Expr<T>, Vec<Stmt<T>>),
+    /// Binds an identifier to each joined row of two tables, evaluating the body.
+    JoinLoop(String, usize, (Expr<T>, Expr<T>), Vec<Stmt<T>>),
     /// An expression (all expressions are statements, but not all statements expressions).
     Expr(Expr<T>),
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -762,6 +762,7 @@ impl UntypedStmt {
                             meta,
                         ))]);
                     }
+                    let join_ty = tuple_a[0].clone();
                     let elem_ty = Type::Tuple(vec![elem_ty_a, elem_ty_b]);
                     let mut body_typed = Vec::with_capacity(body.len());
                     env.push();
@@ -771,7 +772,7 @@ impl UntypedStmt {
                     }
                     env.pop();
                     Ok(Stmt::new(
-                        StmtEnum::JoinLoop(var.clone(), (a, b), body_typed),
+                        StmtEnum::JoinLoop(var.clone(), join_ty, (a, b), body_typed),
                         meta,
                     ))
                 }
@@ -791,7 +792,7 @@ impl UntypedStmt {
                     ))
                 }
             },
-            ast::StmtEnum::JoinLoop(_, _, _) => {
+            ast::StmtEnum::JoinLoop(_, _, _, _) => {
                 unreachable!("Untyped expressions should never be join loops")
             }
         }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -101,6 +101,8 @@ pub enum CircuitError {
     InvalidGate(usize),
     /// The specified output gate does not exist in the circuit.
     InvalidOutput(usize),
+    /// The circuit does not specify any input gates.
+    EmptyInputs,
     /// The circuit does not specify any output gates.
     EmptyOutputs,
     /// The provided circuit has too many gates to be processed.
@@ -141,6 +143,9 @@ impl Circuit {
     pub fn validate(&self) -> Result<(), CircuitError> {
         let mut num_and_gates = 0;
         let wires = self.wires();
+        if self.input_gates.iter().all(|i| *i == 0) {
+            return Err(CircuitError::EmptyInputs);
+        }
         for (i, g) in wires.iter().enumerate() {
             match g {
                 Wire::Input(_) => {}

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -468,16 +468,14 @@ impl TypedStmt {
                 let mut bitonic = vec![];
                 for i in 0..num_elems_a {
                     let mut v = a[i * elem_bits_a..(i + 1) * elem_bits_a].to_vec();
-                    for _ in 0..(max_elem_bits - elem_bits_a) {
-                        v.push(0);
-                    }
+                    v.resize(max_elem_bits, 0);
+                    v.insert(join_ty_size, 0);
                     bitonic.push(v);
                 }
                 for i in (0..num_elems_b).rev() {
                     let mut v = b[i * elem_bits_b..(i + 1) * elem_bits_b].to_vec();
-                    for _ in 0..(max_elem_bits - elem_bits_b) {
-                        v.push(0);
-                    }
+                    v.resize(max_elem_bits, 0);
+                    v.insert(join_ty_size, 1);
                     bitonic.push(v);
                 }
                 let mut offset = num_elems / 2;
@@ -502,10 +500,14 @@ impl TypedStmt {
                 }
                 for slice in bitonic.windows(2) {
                     let mut binding = vec![];
-                    let a = &slice[0][..elem_bits_a];
-                    let b = &slice[1][..elem_bits_b];
-                    binding.extend(a);
-                    binding.extend(b);
+                    let (mut a, mut b) =
+                        circuit.push_sorter(join_ty_size + 1, &slice[0], &slice[1]);
+                    a.remove(join_ty_size);
+                    a.truncate(elem_bits_a);
+                    b.remove(join_ty_size);
+                    b.truncate(elem_bits_b);
+                    binding.extend(&a);
+                    binding.extend(&b);
                     let join_a = &a[..join_ty_size];
                     let join_b = &b[..join_ty_size];
                     let mut join_eq = 1;

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -437,6 +437,9 @@ impl TypedStmt {
                 env.pop();
                 vec![]
             }
+            StmtEnum::JoinLoop(_, _, _, _) => {
+                todo!("compile join loop")
+            }
         }
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -437,7 +437,7 @@ impl TypedStmt {
                 env.pop();
                 vec![]
             }
-            StmtEnum::JoinLoop(_, _, _, _) => {
+            StmtEnum::JoinLoop(_, _, _) => {
                 todo!("compile join loop")
             }
         }

--- a/tests/circuit.rs
+++ b/tests/circuit.rs
@@ -150,3 +150,22 @@ pub fn main(arr1: [u8; 8], arr2: [u8; 8], choice: bool) -> [u8; 8] {
     );
     Ok(())
 }
+
+#[test]
+fn optimize_mapped_arrays() -> Result<(), String> {
+    let prg = "
+pub fn main(arr1: [(u16, u16, u32); 8]) -> [((u16, u16), u32); 8] {
+    let mut arr2 = [((0u16, 0u16), 0u32); 8];
+    let mut i = 0usize;
+    for elem in arr1 {
+        let (a, b, c) = elem;
+        arr2[i] = ((a, b), c);
+        i = i + 1usize;
+    }
+    arr2
+}";
+    let compiled = compile(prg).map_err(|e| e.prettify(prg))?;
+    assert_eq!(compiled.circuit.and_gates(), 0);
+    assert_eq!(compiled.circuit.gates.len(), 2);
+    Ok(())
+}

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -2057,14 +2057,9 @@ fn compile_join_fn() -> Result<(), Error> {
     let prg = "
 pub fn main(rows1: [([u8; 3], u16); 4], rows2: [([u8; 3], u16, u16); 3]) -> u16 {
     let mut result = 0u16;
-    let joined = join(1usize, rows1, rows2);
-    for row in joined {
-        match row {
-            Join::Some((_, field1), (_, field2, field3)) => {
-                result = result + field1 + field2 + field3;
-            },
-            Join::None => {},
-        }
+    for row in join(1usize, rows1, rows2) {
+        let ((_, field1), (_, field2, field3)) = row;
+        result = result + field1 + field2 + field3;
     }
     result
 }

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -2055,7 +2055,7 @@ pub fn main(array: [u16; MY_CONST]) -> u16 {
 #[test]
 fn compile_join_fn() -> Result<(), Error> {
     let prg = "
-pub fn main(rows1: [([u8; 3], u16); 4], rows2: [([u8; 3], u16, u16); 3]) -> u16 {
+pub fn main(rows1: [([u8; 3], u16); 4], rows2: [([u8; 3], u16, u16); 4]) -> u16 {
     let mut result = 0u16;
     for row in join(rows1, rows2) {
         let ((_, field1), (_, field2, field3)) = row;
@@ -2089,6 +2089,11 @@ pub fn main(rows1: [([u8; 3], u16); 4], rows2: [([u8; 3], u16, u16); 3]) -> u16 
     let id_qux = Literal::Array(vec![
         Literal::NumUnsigned(113, UnsignedNumType::U8),
         Literal::NumUnsigned(117, UnsignedNumType::U8),
+        Literal::NumUnsigned(120, UnsignedNumType::U8),
+    ]);
+    let id_xxx = Literal::Array(vec![
+        Literal::NumUnsigned(120, UnsignedNumType::U8),
+        Literal::NumUnsigned(120, UnsignedNumType::U8),
         Literal::NumUnsigned(120, UnsignedNumType::U8),
     ]);
     eval.set_literal(Literal::Array(vec![
@@ -2125,6 +2130,11 @@ pub fn main(rows1: [([u8; 3], u16); 4], rows2: [([u8; 3], u16, u16); 3]) -> u16 
             id_qux.clone(),
             Literal::NumUnsigned(8, UnsignedNumType::U16),
             Literal::NumUnsigned(9, UnsignedNumType::U16),
+        ]),
+        Literal::Tuple(vec![
+            id_xxx.clone(),
+            Literal::NumUnsigned(10, UnsignedNumType::U16),
+            Literal::NumUnsigned(11, UnsignedNumType::U16),
         ]),
     ]))
     .unwrap();

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -2057,7 +2057,7 @@ fn compile_join_fn() -> Result<(), Error> {
     let prg = "
 pub fn main(rows1: [([u8; 3], u16); 4], rows2: [([u8; 3], u16, u16); 3]) -> u16 {
     let mut result = 0u16;
-    for row in join(1usize, rows1, rows2) {
+    for row in join(rows1, rows2) {
         let ((_, field1), (_, field2, field3)) = row;
         result = result + field1 + field2 + field3;
     }

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -2053,9 +2053,9 @@ pub fn main(array: [u16; MY_CONST]) -> u16 {
 }
 
 #[test]
-fn compile_join_fn() -> Result<(), Error> {
+fn compile_join_loop() -> Result<(), Error> {
     let prg = "
-pub fn main(rows1: [([u8; 3], u16); 4], rows2: [([u8; 3], u16, u16); 4]) -> u16 {
+pub fn main(rows1: [([u8; 3], u16); 4], rows2: [([u8; 3], u16, u16); 3]) -> u16 {
     let mut result = 0u16;
     for row in join(rows1, rows2) {
         let ((_, field1), (_, field2, field3)) = row;
@@ -2089,11 +2089,6 @@ pub fn main(rows1: [([u8; 3], u16); 4], rows2: [([u8; 3], u16, u16); 4]) -> u16 
     let id_qux = Literal::Array(vec![
         Literal::NumUnsigned(113, UnsignedNumType::U8),
         Literal::NumUnsigned(117, UnsignedNumType::U8),
-        Literal::NumUnsigned(120, UnsignedNumType::U8),
-    ]);
-    let id_xxx = Literal::Array(vec![
-        Literal::NumUnsigned(120, UnsignedNumType::U8),
-        Literal::NumUnsigned(120, UnsignedNumType::U8),
         Literal::NumUnsigned(120, UnsignedNumType::U8),
     ]);
     eval.set_literal(Literal::Array(vec![
@@ -2130,11 +2125,6 @@ pub fn main(rows1: [([u8; 3], u16); 4], rows2: [([u8; 3], u16, u16); 4]) -> u16 
             id_qux.clone(),
             Literal::NumUnsigned(8, UnsignedNumType::U16),
             Literal::NumUnsigned(9, UnsignedNumType::U16),
-        ]),
-        Literal::Tuple(vec![
-            id_xxx.clone(),
-            Literal::NumUnsigned(10, UnsignedNumType::U16),
-            Literal::NumUnsigned(11, UnsignedNumType::U16),
         ]),
     ]))
     .unwrap();


### PR DESCRIPTION
This PR implements support for joining together two (sorted) arrays of tuples efficiently, using a bitonic sorting network.

The feature is best explained in the language tour:

<img width="932" alt="Screenshot 2024-07-24 at 19 42 59" src="https://github.com/user-attachments/assets/656203e3-340e-41df-a6de-c6a0c82a1610">
