### PR TITLE
Implement JsonSchema for Literal type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,5 @@ jobs:
             ~/.rustup
           key: ${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}
       - run: cargo build --features="bin"
-      - run: cargo test --features="serde"
+      - run: cargo test --features="serde" --features="json_schema"
       - run: cargo clippy -- -Dwarnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +214,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,12 +278,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -306,6 +356,18 @@ dependencies = [
  "winapi",
  "wio",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_logger"
@@ -426,12 +488,24 @@ name = "garble_lang"
 version = "0.7.0"
 dependencies = [
  "clap",
+ "insta",
  "plotters",
  "quickcheck",
  "quickcheck_macros",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -508,6 +582,20 @@ dependencies = [
  "jpeg-decoder",
  "num-traits",
  "png",
+]
+
+[[package]]
+name = "insta"
+version = "1.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+dependencies = [
+ "console",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "serde",
+ "similar",
 ]
 
 [[package]]
@@ -617,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "option-ext"
@@ -644,6 +732,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cf07ef4804cfa9aea3b04a7bbdd5a40031dbb6b4f2cbaf2b011666c80c5b4f2"
 dependencies = [
  "rustc_version",
+]
+
+[[package]]
+name = "pest"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
 ]
 
 [[package]]
@@ -787,6 +920,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +1006,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +1057,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +1077,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -901,6 +1101,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "strsim"
@@ -959,6 +1165,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1187,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "garble_lang"
 version = "0.7.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.60.0" # todo update this
 description = "Turing-Incomplete Programming Language for Multi-Party Computation with Garbled Circuits"
 repository = "https://github.com/sine-fdn/garble/"
 license = "MIT"
@@ -24,10 +24,14 @@ required-features = ["bin"]
 clap = { version = "4.5.41", features = ["derive"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 plotters = { version = "0.3.7", optional = true }
+schemars = { version = "0.9", optional = true }
+
 
 [features]
-bin = ["clap"]
-plot = ["plotters"]
+bin = ["dep:clap"]
+plot = ["dep:plotters"]
+json_schema = ["dep:schemars", "serde"]
+serde = ["dep:serde"]
 
 [dev-dependencies]
 quickcheck = "1"
@@ -35,3 +39,4 @@ quickcheck_macros = "1"
 serde_json = "1.0.140"
 serde = { version = "1.0", features = ["derive"] }
 tempfile = "3"
+insta = { version = "1.43.1", features = ["json", "redactions"] }

--- a/garble_docs/src/serde.md
+++ b/garble_docs/src/serde.md
@@ -50,3 +50,7 @@ Here are some example Garble literals and how they would be serialized as JSON:
 | `FooBar::Foo`                    | `{"Enum":["FooBar","Foo","Unit"]}`                       |
 | `FooBar::Bar(true, false)`       | `{"Enum":["FooBar","Bar",{"Tuple":["True","False"]}]}`   |
 | `2u8..10u8`                      | `{"Range":[2,10,"U8"]}`                                  |
+
+
+## Json-Schema
+If you enable the `json_schema` feature (which also enables `serde`) the `Literal` type will implement the [`JsonSchema`](https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html) trait. This enables its inclusion in APIs documented using OpenAPI documentation generators like [aide](https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html) or the [dropshot](https://docs.rs/dropshot/latest/dropshot/) framework.

--- a/src/literal.rs
+++ b/src/literal.rs
@@ -9,6 +9,8 @@ use std::{
     fmt::Display,
 };
 
+#[cfg(feature = "json_schema")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -81,6 +83,7 @@ use crate::{
 /// | `2u8..10u8`                      | `{"Range":[2,10,"U8"]}`                                  |
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub enum Literal {
     /// Literal `true`.
     True,
@@ -107,6 +110,7 @@ pub enum Literal {
 /// A variant literal (either of unit type or containing fields), used by [`Literal::Enum`].
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub enum VariantLiteral {
     /// A unit variant, containing no fields.
     Unit,

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,5 +1,7 @@
 //! Tokens produced by [`crate::scan::scan`].
 
+#[cfg(feature = "json_schema")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -205,6 +207,7 @@ impl std::fmt::Display for TokenEnum {
 /// A suffix indicating the explicit unsigned number type of the literal.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub enum UnsignedNumType {
     /// Unsigned integer type used to index arrays, length depends on the host platform.
     Usize,
@@ -250,6 +253,7 @@ impl std::fmt::Display for UnsignedNumType {
 /// A suffix indicating the explicit signed number type of the literal.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub enum SignedNumType {
     /// 8-bit signed integer type.
     I8,

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -1,0 +1,19 @@
+#![cfg(feature = "json_schema")]
+use garble_lang::literal::Literal;
+use insta::assert_json_snapshot;
+use schemars::schema_for;
+
+/// This is a snapshot test using [insta](https://docs.rs/insta/latest/insta/)
+/// for the json schema of the `Literal` type. If the test fails, you'll need
+/// to update the stored snapshot in the `./snapshots` folder. You can update
+/// the snapshots using the `cargo-insta` tool or using the `INSTA_UPDATE` env
+/// variable (see here https://docs.rs/insta/latest/insta/#writing-tests).
+#[test]
+fn print_literal_schema() {
+    let schema = schema_for!(Literal);
+    assert_json_snapshot!(schema, {
+        // We ignore all descriptions so that changing them doesn't cause
+        // the test to fail.
+        ".**.description" => ""
+    });
+}

--- a/tests/snapshots/schema__print_literal_schema.snap
+++ b/tests/snapshots/schema__print_literal_schema.snap
@@ -1,0 +1,526 @@
+---
+source: tests/schema.rs
+assertion_line: 14
+expression: schema
+---
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Literal",
+  "description": "",
+  "oneOf": [
+    {
+      "description": "",
+      "type": "string",
+      "const": "True"
+    },
+    {
+      "description": "",
+      "type": "string",
+      "const": "False"
+    },
+    {
+      "description": "",
+      "type": "object",
+      "properties": {
+        "NumUnsigned": {
+          "type": "array",
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            },
+            {
+              "$ref": "#/$defs/UnsignedNumType"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "NumUnsigned"
+      ]
+    },
+    {
+      "description": "",
+      "type": "object",
+      "properties": {
+        "NumSigned": {
+          "type": "array",
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "integer",
+              "format": "int64"
+            },
+            {
+              "$ref": "#/$defs/SignedNumType"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "NumSigned"
+      ]
+    },
+    {
+      "description": "",
+      "type": "object",
+      "properties": {
+        "ArrayRepeat": {
+          "type": "array",
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "$ref": "#/$defs/Literal"
+            },
+            {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "ArrayRepeat"
+      ]
+    },
+    {
+      "description": "",
+      "type": "object",
+      "properties": {
+        "Array": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Literal"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "Array"
+      ]
+    },
+    {
+      "description": "",
+      "type": "object",
+      "properties": {
+        "Tuple": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Literal"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "Tuple"
+      ]
+    },
+    {
+      "description": "",
+      "type": "object",
+      "properties": {
+        "Struct": {
+          "type": "array",
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/$defs/Literal"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "Struct"
+      ]
+    },
+    {
+      "description": "",
+      "type": "object",
+      "properties": {
+        "Enum": {
+          "type": "array",
+          "maxItems": 3,
+          "minItems": 3,
+          "prefixItems": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/VariantLiteral"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "Enum"
+      ]
+    },
+    {
+      "description": "",
+      "type": "object",
+      "properties": {
+        "Range": {
+          "type": "array",
+          "maxItems": 3,
+          "minItems": 3,
+          "prefixItems": [
+            {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            },
+            {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            },
+            {
+              "$ref": "#/$defs/UnsignedNumType"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "Range"
+      ]
+    }
+  ],
+  "$defs": {
+    "Literal": {
+      "description": "",
+      "oneOf": [
+        {
+          "description": "",
+          "type": "string",
+          "const": "True"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "const": "False"
+        },
+        {
+          "description": "",
+          "type": "object",
+          "properties": {
+            "NumUnsigned": {
+              "type": "array",
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0
+                },
+                {
+                  "$ref": "#/$defs/UnsignedNumType"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "NumUnsigned"
+          ]
+        },
+        {
+          "description": "",
+          "type": "object",
+          "properties": {
+            "NumSigned": {
+              "type": "array",
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "$ref": "#/$defs/SignedNumType"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "NumSigned"
+          ]
+        },
+        {
+          "description": "",
+          "type": "object",
+          "properties": {
+            "ArrayRepeat": {
+              "type": "array",
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "$ref": "#/$defs/Literal"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ArrayRepeat"
+          ]
+        },
+        {
+          "description": "",
+          "type": "object",
+          "properties": {
+            "Array": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Literal"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Array"
+          ]
+        },
+        {
+          "description": "",
+          "type": "object",
+          "properties": {
+            "Tuple": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Literal"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Tuple"
+          ]
+        },
+        {
+          "description": "",
+          "type": "object",
+          "properties": {
+            "Struct": {
+              "type": "array",
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "prefixItems": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "$ref": "#/$defs/Literal"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Struct"
+          ]
+        },
+        {
+          "description": "",
+          "type": "object",
+          "properties": {
+            "Enum": {
+              "type": "array",
+              "maxItems": 3,
+              "minItems": 3,
+              "prefixItems": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/$defs/VariantLiteral"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Enum"
+          ]
+        },
+        {
+          "description": "",
+          "type": "object",
+          "properties": {
+            "Range": {
+              "type": "array",
+              "maxItems": 3,
+              "minItems": 3,
+              "prefixItems": [
+                {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0
+                },
+                {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0
+                },
+                {
+                  "$ref": "#/$defs/UnsignedNumType"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Range"
+          ]
+        }
+      ]
+    },
+    "SignedNumType": {
+      "description": "",
+      "oneOf": [
+        {
+          "description": "",
+          "type": "string",
+          "const": "I8"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "const": "I16"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "const": "I32"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "const": "I64"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "const": "Unspecified"
+        }
+      ]
+    },
+    "UnsignedNumType": {
+      "description": "",
+      "oneOf": [
+        {
+          "description": "",
+          "type": "string",
+          "const": "Usize"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "const": "U8"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "const": "U16"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "const": "U32"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "const": "U64"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "const": "Unspecified"
+        }
+      ]
+    },
+    "VariantLiteral": {
+      "description": "",
+      "oneOf": [
+        {
+          "description": "",
+          "type": "string",
+          "const": "Unit"
+        },
+        {
+          "description": "",
+          "type": "object",
+          "properties": {
+            "Tuple": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Literal"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Tuple"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adds `JsonSchema` implementations for Literal and its contained types if the `json_schema` feature is enabled. This facilitates their use in OpenAPI docs generators.