### PR TITLE
Array const expr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "garble_lang"
 version = "0.7.0"
 edition = "2021"
-rust-version = "1.60.0" # todo update this
+rust-version = "1.82.0"
 description = "Turing-Incomplete Programming Language for Multi-Party Computation with Garbled Circuits"
 repository = "https://github.com/sine-fdn/garble/"
 license = "MIT"

--- a/garble_docs/src/guide/const.md
+++ b/garble_docs/src/guide/const.md
@@ -39,6 +39,31 @@ pub fn main(x: u16) -> u16 {
 
 > Garble currently does not support type inference in const declarations, which is why you always have to use type suffixes even for simple number literals, e.g. use `2u16` instead of `2`.
 
+## Addition and Subtraction
+
+Similar to `min()` and `max()` const declarations can use addition and substraction to calculate more complex constants. Arithmetic operations on constants are defined to wrap in case of an overflow.
+
+```rust
+const MY_CONST: usize = min(PARTY_0::MY_CONST, PARTY_1::MY_CONST) + 5usize;
+const DEPENDENT_CONST: usize = max(MY_CONST, PARTY_1::MY_CONST - 2usize) + 6usize;
+
+pub fn main(x: u16) -> u16 {
+    let array = [2; DEPENDENT_CONST];
+    x + array[1] + DEPENDENT_CONST as u16
+}
+```
+
+## Arrays with a `const` expression size
+
+An arrays size can be can be an inline constant expression instead of a fixed size or named constant. These types of arrays are currently
+limited in functionality and serve mostly as the return type of compiler built-in generic functions.
+
+```rust
+pub fn main(i: usize, arr: [i32; const { 2 + 3 } ]) -> i32 {
+    arr[i]
+}
+```
+
 ## A Dynamic Number of Parties
 
 Using `const` declarations is especially useful for writing Garble programs that work for any number of parties. Simply use a single array as the argument of the main function, Garble will then assume that each array element is provided by a different party:

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, fmt::Debug};
 use crate::{
     ast::Type,
     circuit::{Circuit, EvalPanic, USIZE_BITS},
-    compile::{signed_to_bits, unsigned_to_bits},
+    compile::{resolve_const_expr_usize, signed_to_bits, unsigned_to_bits},
     literal::Literal,
     token::{SignedNumType, UnsignedNumType},
     CompileTimeError, TypedFnDef, TypedProgram,
@@ -240,6 +240,10 @@ pub(crate) fn resolve_const_type(ty: &Type, const_sizes: &HashMap<String, usize>
         Type::ArrayConst(elem_ty, size) => Type::Array(
             Box::new(resolve_const_type(elem_ty, const_sizes)),
             *const_sizes.get(size).unwrap(),
+        ),
+        Type::ArrayConstExpr(elem_ty, size) => Type::Array(
+            Box::new(resolve_const_type(elem_ty, const_sizes)),
+            resolve_const_expr_usize(size, const_sizes),
         ),
         Type::Tuple(elems) => Type::Tuple(
             elems

--- a/src/token.rs
+++ b/src/token.rs
@@ -304,7 +304,7 @@ impl std::fmt::Display for SignedNumType {
 }
 
 /// The location of a token in the source code, from start `(line, column)` to end `(line, column)`.
-#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MetaInfo {
     /// The line and column of the start of the token.

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -1,0 +1,32 @@
+use garble_lang::{
+    parse::{ParseError, ParseErrorEnum},
+    scan::scan,
+    Error, UntypedProgram,
+};
+
+#[test]
+// TODO we might want to allow this in the future (robinhundt 31.07.25)
+fn reject_array_repeat_const_expr_size() -> Result<(), Error> {
+    let prg = "
+pub fn main(b: u8) -> u8 {
+  let a = [4; const { 2 + 3 } ];
+  b
+}
+";
+    let e = scan(prg)?.parse();
+    let e = assert_single_parse_error(e);
+    assert!(matches!(e, ParseErrorEnum::InvalidArraySize));
+    Ok(())
+}
+
+fn assert_single_parse_error(e: Result<UntypedProgram, Vec<ParseError>>) -> ParseErrorEnum {
+    if let Err(mut e) = e {
+        if e.len() == 1 {
+            e.pop().unwrap().0
+        } else {
+            panic!("Expected a single parse error, but found {e:?}");
+        }
+    } else {
+        panic!("Expected an error, but found {e:?}");
+    }
+}


### PR DESCRIPTION
Implement Arrays with const expr size

This PR adds a new AST node for arrays whose size is computed
by a `const {}` expression. These expressions can use
literals, max, min, and newly added other consts, addition and subtraction.

This is in preparation for #213. Currently the `ConstExpr` of an `ArrayConstExpr` is part of the type, with the `MetaInfo` being ignored. This is not ideal as explained in https://github.com/sine-fdn/garble-lang/pull/213#issuecomment-3103455446 . We will change this in a follow-up PR (issue #219).

Note that the diff looks larger than it is, because I moved some functions to a different scope so that they're more accessible.