### PR TITLE
Fix join iter with duplicates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,5 @@ jobs:
           key: ${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}
       - run: cargo build --features="bin"
       - run: cargo test --features="serde" --features="json_schema"
+      - run: cargo fmt --all --check
       - run: cargo clippy -- -Dwarnings

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -405,21 +405,9 @@ impl TypedStmt {
                     match access {
                         Accessor::ArrayAccess { array_ty, index } => {
                             let array_before_access = collection.clone();
-                            let (elem_ty, num_elems) = match &array_ty {
-                                Type::Array(elem_ty, size) => (elem_ty, *size),
-                                Type::ArrayConst(elem_ty, size) => {
-                                    (elem_ty, *circuit.const_sizes().get(size).unwrap())
-                                }
-                                Type::ArrayConstExpr(elem_ty, size) => (
-                                    elem_ty,
-                                    resolve_const_expr_usize(size, circuit.const_sizes()),
-                                ),
-                                ty => {
-                                    panic!("Found a non-array value in an array access expr: {ty}")
-                                }
-                            };
-                            let elem_bits =
-                                elem_ty.size_in_bits_for_defs(prg, circuit.const_sizes());
+                            let (elem_bits, num_elems) = array_ty
+                                .unwrap_array_size(prg, circuit.const_sizes())
+                                .expect("Found a non-array value in an array access expr: {ty}");
                             let mut index = index.compile(prg, env, circuit);
                             let index_bits = Type::Unsigned(UnsignedNumType::Usize)
                                 .size_in_bits_for_defs(prg, circuit.const_sizes());
@@ -597,14 +585,10 @@ impl TypedStmt {
                 vec![]
             }
             StmtEnum::ForEachLoop(pattern, array, body) => {
-                let elem_in_bits = match &array.ty {
-                    Type::Array(elem_ty, _)
-                    | Type::ArrayConst(elem_ty, _)
-                    | Type::ArrayConstExpr(elem_ty, _) => {
-                        elem_ty.size_in_bits_for_defs(prg, circuit.const_sizes())
-                    }
-                    _ => panic!("Found a non-array value in an array access expr"),
-                };
+                let (elem_in_bits, _) = array
+                    .ty
+                    .unwrap_array_size(prg, circuit.const_sizes())
+                    .expect("Found a non-array value in an array access expr");
                 env.push();
                 let array = array.compile(prg, env, circuit);
 
@@ -622,95 +606,37 @@ impl TypedStmt {
                 vec![]
             }
             StmtEnum::JoinLoop(pattern, join_ty, (a, b), body) => {
-                let (elem_bits_a, num_elems_a) = match &a.ty {
-                    Type::Array(elem_ty, size) => (
-                        elem_ty.size_in_bits_for_defs(prg, circuit.const_sizes()),
-                        *size,
-                    ),
-                    Type::ArrayConst(elem_ty, size) => (
-                        elem_ty.size_in_bits_for_defs(prg, circuit.const_sizes()),
-                        *circuit.const_sizes().get(size).unwrap(),
-                    ),
-                    Type::ArrayConstExpr(elem_ty, size) => (
-                        elem_ty.size_in_bits_for_defs(prg, circuit.const_sizes()),
-                        resolve_const_expr_usize(size, circuit.const_sizes()),
-                    ),
-                    _ => panic!("Found a non-array value in an array access expr"),
-                };
-                let (elem_bits_b, num_elems_b) = match &b.ty {
-                    Type::Array(elem_ty, size) => (
-                        elem_ty.size_in_bits_for_defs(prg, circuit.const_sizes()),
-                        *size,
-                    ),
-                    Type::ArrayConst(elem_ty, size) => (
-                        elem_ty.size_in_bits_for_defs(prg, circuit.const_sizes()),
-                        *circuit.const_sizes().get(size).unwrap(),
-                    ),
-                    Type::ArrayConstExpr(elem_ty, size) => (
-                        elem_ty.size_in_bits_for_defs(prg, circuit.const_sizes()),
-                        resolve_const_expr_usize(size, circuit.const_sizes()),
-                    ),
-                    _ => panic!("Found a non-array value in an array access expr"),
-                };
-                let max_elem_bits = max(elem_bits_a, elem_bits_b);
-                let num_elems = (num_elems_a + num_elems_b).next_power_of_two();
-                let join_ty_size = join_ty.size_in_bits_for_defs(prg, circuit.const_sizes());
-                let a = a.compile(prg, env, circuit);
-                let b = b.compile(prg, env, circuit);
-                let mut bitonic = vec![];
-                let num_empty_elems = num_elems - num_elems_a - num_elems_b;
-                for _ in 0..num_empty_elems {
-                    bitonic.push(vec![0; max_elem_bits + 1]);
-                }
-                for i in 0..num_elems_a {
-                    let mut v = a[i * elem_bits_a..(i + 1) * elem_bits_a].to_vec();
-                    v.resize(max_elem_bits, 0);
-                    v.insert(join_ty_size, 0);
-                    bitonic.push(v);
-                }
-                for i in (0..num_elems_b).rev() {
-                    let mut v = b[i * elem_bits_b..(i + 1) * elem_bits_b].to_vec();
-                    v.resize(max_elem_bits, 0);
-                    v.insert(join_ty_size, 1);
-                    bitonic.push(v);
-                }
-                circuit.push_bitonic_merger(join_ty_size, true, &mut bitonic);
-                for slice in bitonic.windows(2).skip(num_empty_elems) {
-                    let mut binding = vec![];
-                    let (mut a, mut b) =
-                        circuit.push_sorter(join_ty_size + 1, &slice[0], &slice[1]);
-                    a.remove(join_ty_size);
-                    a.truncate(elem_bits_a);
-                    b.remove(join_ty_size);
-                    b.truncate(elem_bits_b);
-                    binding.extend(&a);
-                    binding.extend(&b);
-                    let join_a = &a[..join_ty_size];
-                    let join_b = &b[..join_ty_size];
-                    let mut join_eq = 1;
-                    for i in 0..join_ty_size {
-                        let eq = circuit.push_eq(join_a[i], join_b[i]);
-                        join_eq = circuit.push_and(join_eq, eq);
-                    }
+                compile_bitonic_merge(
+                    prg,
+                    env,
+                    circuit,
+                    join_ty,
+                    a,
+                    b,
+                    MergeMode::JoinLoop {
+                        process_binding: &mut |env, circuit, join_eq, binding| {
+                            let panic_before_branches = circuit.peek_panic().clone();
 
-                    let panic_before_branches = circuit.peek_panic().clone();
+                            let mut env_if_join = env.clone();
+                            env_if_join.push();
+                            pattern.compile(&binding, prg, &mut env_if_join, circuit);
 
-                    let mut env_if_join = env.clone();
-                    env_if_join.push();
-                    pattern.compile(&binding, prg, &mut env_if_join, circuit);
+                            for stmt in body {
+                                stmt.compile(prg, &mut env_if_join, circuit);
+                            }
+                            env_if_join.pop();
 
-                    for stmt in body {
-                        stmt.compile(prg, &mut env_if_join, circuit);
-                    }
-                    env_if_join.pop();
+                            let panic_if_join =
+                                circuit.replace_panic_with(panic_before_branches.clone());
 
-                    let panic_if_join = circuit.replace_panic_with(panic_before_branches.clone());
-
-                    *env = circuit.mux_envs(join_eq, env_if_join, env.clone());
-                    let muxed_panic =
-                        circuit.mux_panic(join_eq, &panic_if_join, &panic_before_branches);
-                    circuit.replace_panic_with(muxed_panic);
-                }
+                            *env = circuit.mux_envs(join_eq, env_if_join, env.clone());
+                            let muxed_panic =
+                                circuit.mux_panic(join_eq, &panic_if_join, &panic_before_branches);
+                            circuit.replace_panic_with(muxed_panic);
+                            vec![]
+                        },
+                    },
+                );
                 vec![]
             }
         }
@@ -794,14 +720,10 @@ impl TypedExpr {
                 array
             }
             ExprEnum::ArrayAccess(array, index) => {
-                let num_elems = match &array.ty {
-                    Type::Array(_, size) => *size,
-                    Type::ArrayConst(_, size) => *circuit.const_sizes().get(size).unwrap(),
-                    Type::ArrayConstExpr(_, size) => {
-                        resolve_const_expr_usize(size, circuit.const_sizes())
-                    }
-                    _ => panic!("Found a non-array value in an array access expr"),
-                };
+                let (_, num_elems) = array
+                    .ty
+                    .unwrap_array_size(prg, circuit.const_sizes())
+                    .expect("Found a non-array value in an array access expr");
                 let elem_bits = ty.size_in_bits_for_defs(prg, circuit.const_sizes());
                 let mut array = array.compile(prg, env, circuit);
                 let mut index = index.compile(prg, env, circuit);
@@ -1201,87 +1123,24 @@ impl TypedExpr {
             }) => {
                 let a = &args[0];
                 let b = &args[1];
-                let unwrap_arr_elem_ty_and_size = |ty: &Type| match ty {
-                    Type::Array(elem_ty, size) => (
-                        elem_ty.size_in_bits_for_defs(prg, circuit.const_sizes()),
-                        *size,
-                    ),
-                    Type::ArrayConst(elem_ty, size) => (
-                        elem_ty.size_in_bits_for_defs(prg, circuit.const_sizes()),
-                        *circuit.const_sizes().get(size).unwrap(),
-                    ),
-                    Type::ArrayConstExpr(elem_ty, size) => {
-                        let elem_bits = elem_ty.size_in_bits_for_defs(prg, circuit.const_sizes());
-                        let size = resolve_const_expr_usize(size, circuit.const_sizes());
-                        (elem_bits, size)
-                    }
-                    _ => panic!("Found a non-array value in an array access expr"),
-                };
-                let (elem_bits_a, num_elems_a) = unwrap_arr_elem_ty_and_size(&a.ty);
-                let (elem_bits_b, num_elems_b) = unwrap_arr_elem_ty_and_size(&b.ty);
-                let max_elem_bits = max(elem_bits_a, elem_bits_b);
-                let num_elems = (num_elems_a + num_elems_b).next_power_of_two();
-                let join_ty_size = join_ty.size_in_bits_for_defs(prg, circuit.const_sizes());
-                let a = a.compile(prg, env, circuit);
-                let b = b.compile(prg, env, circuit);
-                let mut bitonic = vec![];
-                let num_empty_elems = num_elems - num_elems_a - num_elems_b;
-                for _ in 0..num_empty_elems {
-                    bitonic.push(vec![0; max_elem_bits + 1]);
-                }
-                for i in 0..num_elems_a {
-                    let mut v = a[i * elem_bits_a..(i + 1) * elem_bits_a].to_vec();
-                    v.resize(max_elem_bits, 0);
-                    // We insert a tag bit after the the join_ty to distinguish between elements from
-                    // a and b. Here it is 0
-                    v.insert(join_ty_size, 0);
-                    bitonic.push(v);
-                }
-                for i in (0..num_elems_b).rev() {
-                    let mut v = b[i * elem_bits_b..(i + 1) * elem_bits_b].to_vec();
-                    v.resize(max_elem_bits, 0);
-                    // Here the tag bit is 1
-                    v.insert(join_ty_size, 1);
-                    bitonic.push(v);
-                }
-                // Include the tag bit in the sorting of the merger
-                circuit.push_bitonic_merger(join_ty_size + 1, true, &mut bitonic);
-                let mut joined = Vec::with_capacity(num_elems_a + num_elems_b - 1);
-                for slice in bitonic.windows(2).skip(num_empty_elems) {
-                    // Insert a dummy false element at the first position,
-                    // we will set this to the bool indicating whether the element is part of
-                    // the join
-                    let mut binding: Vec<GateIndex> = vec![0];
-                    // Unfortunately, there currently is no `windows_mut`, so we clone
-                    let mut a = slice[0].clone();
-                    let mut b = slice[1].clone();
-                    // Remove the tag bit
-                    let tag_a = a.remove(join_ty_size);
-                    // and the padding
-                    a.truncate(elem_bits_a);
-                    let tag_b = b.remove(join_ty_size);
-                    b.truncate(elem_bits_b);
-                    binding.extend(&a);
-                    // we only need to include the other element if we have assoc data
-                    // in which case the return of bitonic_sort is (bool, tuple_a, tuple_b)
-                    if *has_assoc_data {
-                        binding.extend(&b);
-                    }
-                    let join_a = &a[..join_ty_size];
-                    let join_b = &b[..join_ty_size];
-                    let mut join_eq = circuit.push_eq_circuit(join_a, join_b);
-                    // Ensure that the join only includes elements which are actually present in both datasets
-                    // i.e. the tag is different. Guards against duplicates in one of the datasets
-                    let tags_differ = circuit.push_xor(tag_a, tag_b);
-                    join_eq = circuit.push_and(join_eq, tags_differ);
-
-                    // If an element is not part of the join (join_eq = false), we insert an all 0 dummy element
-                    for g in binding.iter_mut().skip(1) {
-                        *g = circuit.push_mux(join_eq, *g, 0);
-                    }
-                    binding[0] = join_eq;
-                    joined.push(binding);
-                }
+                let mut joined = compile_bitonic_merge(
+                    prg,
+                    env,
+                    circuit,
+                    join_ty,
+                    a,
+                    b,
+                    MergeMode::JoinFunc {
+                        include_b: *has_assoc_data,
+                        process_binding: &mut |_, circuit, join_eq, mut binding| {
+                            // If an element is not part of the join (join_eq = false), we insert an all 0 dummy element
+                            for g in binding.iter_mut().skip(1) {
+                                *g = circuit.push_mux(join_eq, *g, 0);
+                            }
+                            binding
+                        },
+                    },
+                );
                 // Sort the output on the join_eq bool so the positions of the joined elements doesn't leak
                 // data about the input datasets
                 circuit.push_bitonic_sorter(1, &mut joined);
@@ -1571,6 +1430,26 @@ impl TypedPattern {
 }
 
 impl Type {
+    /// Returns Some((el_size, array_length)) for array types or None
+    pub(crate) fn unwrap_array_size(
+        &self,
+        prg: &TypedProgram,
+        const_sizes: &HashMap<String, usize>,
+    ) -> Option<(usize, usize)> {
+        Some(match self {
+            Type::Array(elem_ty, size) => (elem_ty.size_in_bits_for_defs(prg, const_sizes), *size),
+            Type::ArrayConst(elem_ty, size) => (
+                elem_ty.size_in_bits_for_defs(prg, const_sizes),
+                *const_sizes.get(size).unwrap(),
+            ),
+            Type::ArrayConstExpr(elem_ty, size) => (
+                elem_ty.size_in_bits_for_defs(prg, const_sizes),
+                resolve_const_expr_usize(size, const_sizes),
+            ),
+            _ => return None,
+        })
+    }
+
     pub(crate) fn size_in_bits_for_defs(
         &self,
         prg: &TypedProgram,
@@ -1687,6 +1566,127 @@ pub(crate) fn wires_as_unsigned(wires: &[bool]) -> u64 {
         n += (output as u64) << (wires.len() - 1 - i);
     }
     n
+}
+
+enum MergeMode<F> {
+    JoinLoop { process_binding: F },
+    JoinFunc { include_b: bool, process_binding: F },
+}
+
+impl<F> MergeMode<F> {
+    fn is_join_func(&self) -> bool {
+        match self {
+            MergeMode::JoinLoop { .. } => false,
+            MergeMode::JoinFunc { .. } => true,
+        }
+    }
+
+    fn include_b_in_binding(&self) -> bool {
+        match self {
+            MergeMode::JoinLoop { .. } => true,
+            MergeMode::JoinFunc { include_b, .. } => *include_b,
+        }
+    }
+}
+
+type ProcessBindingFunc<'a> = &'a mut dyn FnMut(
+    &mut Env<Vec<GateIndex>>,
+    &mut CircuitBuilder,
+    GateIndex,
+    Vec<GateIndex>,
+) -> Vec<GateIndex>;
+
+/// Compile bitonic merge of two array expressions.
+///
+/// This is a building block for compiling [`StmtEnum::JoinLoop`] and [`ExprEnum::BuiltInFnCall`].
+/// Their `compile` methods call this function and post process the binding differently.
+fn compile_bitonic_merge(
+    prg: &TypedProgram,
+    env: &mut Env<Vec<GateIndex>>,
+    circuit: &mut CircuitBuilder,
+    join_ty: &Type,
+    a: &TypedExpr,
+    b: &TypedExpr,
+    mut mode: MergeMode<ProcessBindingFunc>,
+) -> Vec<Vec<GateIndex>> {
+    let (elem_bits_a, num_elems_a) =
+        a.ty.unwrap_array_size(prg, circuit.const_sizes())
+            .expect("Found a non-array value in an array access expr");
+    let (elem_bits_b, num_elems_b) =
+        b.ty.unwrap_array_size(prg, circuit.const_sizes())
+            .expect("Found a non-array value in an array access expr");
+    let max_elem_bits = max(elem_bits_a, elem_bits_b);
+    let num_elems = (num_elems_a + num_elems_b).next_power_of_two();
+    let join_ty_size = join_ty.size_in_bits_for_defs(prg, circuit.const_sizes());
+    let a = a.compile(prg, env, circuit);
+    let b = b.compile(prg, env, circuit);
+    let mut bitonic = vec![];
+    let num_empty_elems = num_elems - num_elems_a - num_elems_b;
+    for _ in 0..num_empty_elems {
+        bitonic.push(vec![0; max_elem_bits + 1]);
+    }
+    for i in 0..num_elems_a {
+        let mut v = a[i * elem_bits_a..(i + 1) * elem_bits_a].to_vec();
+        v.resize(max_elem_bits, 0);
+        // We insert a tag bit after the the join_ty to distinguish between elements from
+        // a and b. Here it is 0
+        v.insert(join_ty_size, 0);
+        bitonic.push(v);
+    }
+    for i in (0..num_elems_b).rev() {
+        let mut v = b[i * elem_bits_b..(i + 1) * elem_bits_b].to_vec();
+        v.resize(max_elem_bits, 0);
+        // Here the tag bit is 1
+        v.insert(join_ty_size, 1);
+        bitonic.push(v);
+    }
+    // Include the tag bit in the sorting of the merger
+    circuit.push_bitonic_merger(join_ty_size + 1, true, &mut bitonic);
+    let mut joined = Vec::with_capacity(num_elems_a + num_elems_b - 1);
+    for slice in bitonic.windows(2).skip(num_empty_elems) {
+        let mut binding: Vec<GateIndex> = if mode.is_join_func() {
+            // Insert a dummy false element at the first position,
+            // we will set this to the bool indicating whether the element is part of
+            // the join
+            vec![0]
+        } else {
+            vec![]
+        };
+        // Unfortunately, there currently is no `windows_mut`, so we clone
+        let mut a = slice[0].clone();
+        let mut b = slice[1].clone();
+        // Remove the tag bit
+        let tag_a = a.remove(join_ty_size);
+        // and the padding
+        a.truncate(elem_bits_a);
+        let tag_b = b.remove(join_ty_size);
+        b.truncate(elem_bits_b);
+        binding.extend(&a);
+        // we only need to include the other element if we have assoc data
+        // in which case the return of bitonic_sort is (bool, tuple_a, tuple_b)
+        if mode.include_b_in_binding() {
+            binding.extend(&b);
+        }
+        let join_a = &a[..join_ty_size];
+        let join_b = &b[..join_ty_size];
+        let mut join_eq = circuit.push_eq_circuit(join_a, join_b);
+        // Ensure that the join only includes elements which are actually present in both datasets
+        // i.e. the tag is different. Guards against duplicates in one of the datasets
+        let tags_differ = circuit.push_xor(tag_a, tag_b);
+        join_eq = circuit.push_and(join_eq, tags_differ);
+
+        if let MergeMode::JoinFunc { .. } = &mode {
+            // set previous dummy element to comparison result
+            binding[0] = join_eq;
+        }
+
+        let (MergeMode::JoinLoop { process_binding }
+        | MergeMode::JoinFunc {
+            process_binding, ..
+        }) = &mut mode;
+        joined.push(process_binding(env, circuit, join_eq, binding));
+    }
+    joined
 }
 
 fn extend_to_bits(v: &mut Vec<usize>, ty: &Type, bits: usize) {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 //! Provides useful macros.
 
 /// Create constants for [compile_with_constants](`crate::compile_with_constants`).
-/// 
+///
 /// ## Example
 /// ```
 /// use garble_lang::{garble_consts, compile_with_constants};
@@ -17,7 +17,7 @@
 /// let compiled = compile_with_constants(prg, consts)
 ///     .expect("failed compilation");
 /// ```
-/// 
+///
 #[macro_export]
 macro_rules! garble_consts {
     ($($party:expr => { $($const_name:expr => $val:expr),+}),+) => {

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -2130,7 +2130,7 @@ pub fn main(rows1: [([u8; 3], u16); 5], rows2: [([u8; 3], u16, u16); 3]) -> u16 
     eval.set_literal(
         [
             (b"aaa", 0u16),
-            // duplicate id should not be present in join 
+            // duplicate id should not be present in join
             (b"aaa", 10u16),
             (b"bar", 1u16),
             (b"baz", 2u16),

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -2115,7 +2115,7 @@ pub fn main(array: [u16; MY_CONST], _: u8) -> u16 {
 #[test]
 fn compile_join_loop() -> Result<(), Error> {
     let prg = "
-pub fn main(rows1: [([u8; 3], u16); 4], rows2: [([u8; 3], u16, u16); 3]) -> u16 {
+pub fn main(rows1: [([u8; 3], u16); 5], rows2: [([u8; 3], u16, u16); 3]) -> u16 {
     let mut result = 0u16;
     for row in join_iter(rows1, rows2) {
         let ((_, field1), (_, field2, field3)) = row;
@@ -2130,6 +2130,8 @@ pub fn main(rows1: [([u8; 3], u16); 4], rows2: [([u8; 3], u16, u16); 3]) -> u16 
     eval.set_literal(
         [
             (b"aaa", 0u16),
+            // duplicate id should not be present in join 
+            (b"aaa", 10u16),
             (b"bar", 1u16),
             (b"baz", 2u16),
             (b"qux", 3u16),


### PR DESCRIPTION
closes #215

I've also refactored the compilation of the join loop and join func into a common function to reduce code duplication.

Stacked on #230 