### PR TITLE
Optimize circuit conversion memory consumption

### DIFF
--- a/src/register_circuit.rs
+++ b/src/register_circuit.rs
@@ -277,8 +277,8 @@ impl<'c> RegisterAllocator<'c> {
             last_used,
             free_regs: vec![],
             next_reg: 0,
-            wire_map: HashMap::with_capacity(circ.wires_len()),
-            insts: Vec::with_capacity(circ.gates.len()),
+            wire_map: HashMap::new(),
+            insts: Vec::with_capacity(circ.wires_len()),
             and_ops: 0,
         }
     }


### PR DESCRIPTION
The wire map was unnecessarily large since we remove entries at their last use and the insts Vec was too small, causing a large realloc.