### PR TITLE
ci: pin hashes of actions in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,23 +7,13 @@ jobs:
     name: Test Rust
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
       - name: Install latest stable
-        uses: dtolnay/rust-toolchain@master
-        id: toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           toolchain: stable
           components: clippy, rustfmt
-      - name: Cache target
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-default-target-and-lockfile
-        with:
-          path: |
-            target
-            Cargo.lock
-            ~/.rustup
-          key: ${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
       - run: cargo build --features="bin"
       - run: cargo test --features="serde" --features="json_schema"
       - run: cargo fmt --all --check


### PR DESCRIPTION
Use swatinem/rust-cache instead of manually specifying cached directories.