### PR TITLE
ci: improved security of publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,12 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           toolchain: stable
       - run: cargo test --features="serde"
       - run: cargo clippy -- -Dwarnings
-      - run: cargo publish --token ${CRATES_TOKEN}
+      - run: cargo publish
         env:
-          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
- Pin SHAs of actions
- use dtolnay/rust-toolchain instead of deprecated actions-rs
- pass registry in env variable instead of process arg