### PR TITLE
Resolve constants when parsing circuit input string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,8 @@ impl GarbleProgram {
         let Some(param) = self.main.params.get(arg_index) else {
             return Err(EvalError::InvalidArgIndex(arg_index));
         };
-        let literal = Literal::parse(&self.program, &param.ty, literal)
+        let ty = resolve_const_type(&param.ty, &self.const_sizes);
+        let literal = Literal::parse(&self.program, &ty, literal)
             .map_err(EvalError::LiteralParseError)?;
         Ok(GarbleArgument(literal, &self.program, &self.const_sizes))
     }


### PR DESCRIPTION
A main function with constants works when using `prg.literal_arg` to supply the arguments as it [resolves the constants](https://github.com/sine-fdn/garble-lang/blob/05f49c9a45bdab1e8d777b80a13fd04b8c616306/src/lib.rs#L265), however it does not work when using `prg.parse_arg`. [`check_type`](https://github.com/sine-fdn/garble-lang/blob/7e9fea88b045f8f5776dc307108c32b63da5da63/src/literal.rs#L154) fails as the constants were not resolved. This pull requests fixes this.
